### PR TITLE
docs: Add note on support for copy feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,6 @@ mybranches
 
 **Optional flags**:
 - `--pattern`: specify a custom pattern. This gets passed to `git branch --list <pattern>*`. Defaults to your system username.
+
+> [!IMPORTANT]
+> The "copy to clipboard" feature is currently only supported on macOS.


### PR DESCRIPTION
Currently only supported on macOS.

Windows support will probably arrive soon as it seems like pretty much the same process as macOS (pipe into `clip` instead of `pbcopy`). Linux has similar tools like xclip but these aren't preinstalled on all distros.