### PR TITLE
Fix custom pattern not being reflected in header

### DIFF
--- a/tui.go
+++ b/tui.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"runtime"
@@ -70,7 +71,13 @@ func (m model) mainView() string {
 	const selectedIndicator string = "(*)"
 
 	builder := strings.Builder{}
-	fmt.Fprintf(&builder, "Branches containing '%s'\n\n", selectedStyle.Render(getUsernamePattern()))
+
+	pattern := flag.Lookup("pattern").Value.String()
+	if pattern == "" {
+		pattern = getUsernamePattern()
+	}
+
+	fmt.Fprintf(&builder, "Branches containing '%s'\n\n", selectedStyle.Render(pattern))
 
 	for i := range m.branches {
 		if m.cursorIndex == i {

--- a/tui.go
+++ b/tui.go
@@ -72,10 +72,8 @@ func (m model) mainView() string {
 
 	builder := strings.Builder{}
 
+	// pattern flag defaults to username, so this should always have a value
 	pattern := flag.Lookup("pattern").Value.String()
-	if pattern == "" {
-		pattern = getUsernamePattern()
-	}
 
 	fmt.Fprintf(&builder, "Branches containing '%s'\n\n", selectedStyle.Render(pattern))
 


### PR DESCRIPTION
If a custom pattern is specified via the `--pattern` flag, we still render "Branches containing 'username'" as the header in the main view.

This should be the pattern instead, if one was indeed specified.