### PR TITLE
Create separate cleanup program

### DIFF
--- a/cleanup/cleanup.go
+++ b/cleanup/cleanup.go
@@ -13,6 +13,15 @@ func (e errMsg) Error() string {
 	return e.err.Error()
 }
 
+type cleanUpStage int
+
+const (
+	FetchPrune cleanUpStage = iota
+	Find
+	Delete
+	Done
+)
+
 func startStage(stage cleanUpStage) tea.Cmd {
 	switch stage {
 	case FetchPrune:

--- a/cleanup/cleanup.go
+++ b/cleanup/cleanup.go
@@ -37,12 +37,12 @@ var (
 )
 
 func InitialState() model {
-	s := spinner.New()
-	s.Spinner = spinner.Dot
-	s.Style = spinnerStyle
+	spinnerInit := spinner.New()
+	spinnerInit.Spinner = spinner.Dot
+	spinnerInit.Style = spinnerStyle
 
 	return model{
-		spinner: s,
+		spinner: spinnerInit,
 		stage:   FetchPrune,
 	}
 }

--- a/cleanup/cleanup.go
+++ b/cleanup/cleanup.go
@@ -1,116 +1,58 @@
 package cleanup
 
 import (
-	"fmt"
-	"strings"
+	"time"
 
-	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
+	"github.com/suvanl/mybranches/shared/git"
 )
 
-type cleanUpStage int
-type stageError string
+type errMsg struct{ err error }
 
-const errStageMappingError = stageError("Failed to map CleanupStage to message")
-
-func (e stageError) Error() string {
-	return string(e)
+func (e errMsg) Error() string {
+	return e.err.Error()
 }
 
-const (
-	FetchPrune cleanUpStage = iota
-	Find
-	Delete
-)
-
-type model struct {
-	spinner  spinner.Model
-	stage    cleanUpStage
-	quitting bool
-	err      error
-}
-
-var (
-	spinnerStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("5"))
-	helpStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
-)
-
-func InitialState() model {
-	spinnerInit := spinner.New()
-	spinnerInit.Spinner = spinner.Dot
-	spinnerInit.Style = spinnerStyle
-
-	return model{
-		spinner: spinnerInit,
-		stage:   FetchPrune,
-	}
-}
-
-func (m model) Init() tea.Cmd {
-	return m.spinner.Tick
-}
-
-func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		switch msg.String() {
-		case "q", "ctrl+c":
-			m.quitting = true
-			return m, tea.Quit
-
-		default:
-			return m, nil
-		}
-
-	case error:
-		m.err = msg
-		return m, nil
-
-	default:
-		var cmd tea.Cmd
-		m.spinner, cmd = m.spinner.Update(msg)
-		return m, cmd
-	}
-
-}
-
-func (m model) View() string {
-	if m.err != nil {
-		return m.err.Error()
-	}
-
-	builder := strings.Builder{}
-
-	stageMsg, mappingErr := mapStageToMessage(m.stage)
-	if mappingErr != nil {
-		return mappingErr.Error()
-	}
-
-	fmt.Fprintf(&builder, "\n  %s %s... ", m.spinner.View(), stageMsg)
-	fmt.Fprint(&builder, helpStyle.Render("(q to quit)"))
-
-	if m.quitting {
-		builder.WriteString("\n")
-		return builder.String()
-	}
-
-	return builder.String()
-}
-
-func mapStageToMessage(stage cleanUpStage) (string, error) {
-	var message string
-
+func startStage(stage cleanUpStage) tea.Cmd {
 	switch stage {
 	case FetchPrune:
-		message = "Fetching remote branches"
+		return func() tea.Msg {
+			err := git.FetchPrune()
+			if err != nil {
+				return errMsg{err}
+			}
+			return getNextStage(stage)
+		}
+
 	case Find:
-		message = "Finding local branches not on remote"
+		return func() tea.Msg {
+			time.Sleep(time.Second)
+			return getNextStage(stage)
+		}
+
 	case Delete:
-		message = "Deleting local branches not on remote"
-	default:
-		return "", errStageMappingError
+		return func() tea.Msg {
+			time.Sleep(time.Duration(3) * time.Second)
+			return getNextStage(stage)
+		}
 	}
 
-	return message, nil
+	return nil
+}
+
+func getNextStage(currentStage cleanUpStage) cleanUpStage {
+	var nextStage cleanUpStage
+
+	switch currentStage {
+	case FetchPrune:
+		nextStage = Find
+	case Find:
+		nextStage = Delete
+	case Delete:
+		nextStage = Done
+	case Done:
+		nextStage = Done
+	}
+
+	return cleanUpStage(nextStage)
 }

--- a/cleanup/cleanup.go
+++ b/cleanup/cleanup.go
@@ -1,8 +1,6 @@
 package cleanup
 
 import (
-	"time"
-
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/suvanl/mybranches/shared/git"
 )
@@ -34,9 +32,8 @@ func startStage(stage cleanUpStage) tea.Cmd {
 
 	case Delete:
 		return func() tea.Msg {
-			time.Sleep(time.Second)
-
-			_, err := git.DeleteBranchesNotOnRemote()
+			dryRun := true
+			_, err := git.DeleteBranchesNotOnRemote(dryRun)
 			if err != nil {
 				return errMsg{err}
 			}

--- a/cleanup/cleanup.go
+++ b/cleanup/cleanup.go
@@ -1,0 +1,116 @@
+package cleanup
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type cleanupStage int
+type stageError string
+
+const errStageMappingError = stageError("Failed to map CleanupStage to message")
+
+func (e stageError) Error() string {
+	return string(e)
+}
+
+const (
+	FetchPrune cleanupStage = iota
+	Find
+	Delete
+)
+
+type model struct {
+	spinner  spinner.Model
+	stage    cleanupStage
+	quitting bool
+	err      error
+}
+
+var (
+	spinnerStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("5"))
+	helpStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+)
+
+func InitialState() model {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = spinnerStyle
+
+	return model{
+		spinner: s,
+		stage:   FetchPrune,
+	}
+}
+
+func (m model) Init() tea.Cmd {
+	return m.spinner.Tick
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "q", "ctrl+c":
+			m.quitting = true
+			return m, tea.Quit
+
+		default:
+			return m, nil
+		}
+
+	case error:
+		m.err = msg
+		return m, nil
+
+	default:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+	}
+
+}
+
+func (m model) View() string {
+	if m.err != nil {
+		return m.err.Error()
+	}
+
+	builder := strings.Builder{}
+
+	stageMsg, mappingErr := mapStageToMessage(m.stage)
+	if mappingErr != nil {
+		return mappingErr.Error()
+	}
+
+	fmt.Fprintf(&builder, "\n  %s %s... ", m.spinner.View(), stageMsg)
+	fmt.Fprint(&builder, helpStyle.Render("(q to quit)"))
+
+	if m.quitting {
+		builder.WriteString("\n")
+		return builder.String()
+	}
+
+	return builder.String()
+}
+
+func mapStageToMessage(stage cleanupStage) (string, error) {
+	var message string
+
+	switch stage {
+	case FetchPrune:
+		message = "Fetching remote branches"
+	case Find:
+		message = "Finding local branches not on remote"
+	case Delete:
+		message = "Deleting local branches not on remote"
+	default:
+		return "", errStageMappingError
+	}
+
+	return message, nil
+}

--- a/cleanup/cleanup.go
+++ b/cleanup/cleanup.go
@@ -17,7 +17,6 @@ type cleanUpStage int
 
 const (
 	FetchPrune cleanUpStage = iota
-	Find
 	Delete
 	Done
 )
@@ -30,12 +29,6 @@ func startStage(stage cleanUpStage) tea.Cmd {
 			if err != nil {
 				return errMsg{err}
 			}
-			return getNextStage(stage)
-		}
-
-	case Find:
-		return func() tea.Msg {
-			time.Sleep(time.Second)
 			return getNextStage(stage)
 		}
 
@@ -54,8 +47,6 @@ func getNextStage(currentStage cleanUpStage) cleanUpStage {
 
 	switch currentStage {
 	case FetchPrune:
-		nextStage = Find
-	case Find:
 		nextStage = Delete
 	case Delete:
 		nextStage = Done

--- a/cleanup/cleanup.go
+++ b/cleanup/cleanup.go
@@ -34,7 +34,13 @@ func startStage(stage cleanUpStage) tea.Cmd {
 
 	case Delete:
 		return func() tea.Msg {
-			time.Sleep(time.Duration(3) * time.Second)
+			time.Sleep(time.Second)
+
+			_, err := git.DeleteBranchesNotOnRemote()
+			if err != nil {
+				return errMsg{err}
+			}
+
 			return getNextStage(stage)
 		}
 	}

--- a/cleanup/cleanup.go
+++ b/cleanup/cleanup.go
@@ -9,7 +9,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-type cleanupStage int
+type cleanUpStage int
 type stageError string
 
 const errStageMappingError = stageError("Failed to map CleanupStage to message")
@@ -19,14 +19,14 @@ func (e stageError) Error() string {
 }
 
 const (
-	FetchPrune cleanupStage = iota
+	FetchPrune cleanUpStage = iota
 	Find
 	Delete
 )
 
 type model struct {
 	spinner  spinner.Model
-	stage    cleanupStage
+	stage    cleanUpStage
 	quitting bool
 	err      error
 }
@@ -98,7 +98,7 @@ func (m model) View() string {
 	return builder.String()
 }
 
-func mapStageToMessage(stage cleanupStage) (string, error) {
+func mapStageToMessage(stage cleanUpStage) (string, error) {
 	var message string
 
 	switch stage {

--- a/cleanup/tui.go
+++ b/cleanup/tui.go
@@ -106,8 +106,6 @@ func mapStageToMessage(stage cleanUpStage) (string, error) {
 	switch stage {
 	case FetchPrune:
 		message = "Fetching remote branches"
-	case Find:
-		message = "Finding local branches not on remote"
 	case Delete:
 		message = "Deleting local branches not on remote"
 	case Done:

--- a/cleanup/tui.go
+++ b/cleanup/tui.go
@@ -9,21 +9,13 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-type cleanUpStage int
 type stageError string
-
-const errStageMappingError = stageError("Failed to map CleanupStage to message")
 
 func (e stageError) Error() string {
 	return string(e)
 }
 
-const (
-	FetchPrune cleanUpStage = iota
-	Find
-	Delete
-	Done
-)
+const errStageMappingError = stageError("Failed to map CleanupStage to message")
 
 type model struct {
 	spinner  spinner.Model

--- a/cleanup/tui.go
+++ b/cleanup/tui.go
@@ -1,0 +1,128 @@
+package cleanup
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type cleanUpStage int
+type stageError string
+
+const errStageMappingError = stageError("Failed to map CleanupStage to message")
+
+func (e stageError) Error() string {
+	return string(e)
+}
+
+const (
+	FetchPrune cleanUpStage = iota
+	Find
+	Delete
+	Done
+)
+
+type model struct {
+	spinner  spinner.Model
+	stage    cleanUpStage
+	quitting bool
+	err      error
+}
+
+var (
+	spinnerStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("5"))
+	helpStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+)
+
+func InitialState() model {
+	spinnerInit := spinner.New()
+	spinnerInit.Spinner = spinner.Dot
+	spinnerInit.Style = spinnerStyle
+
+	return model{
+		spinner: spinnerInit,
+		stage:   FetchPrune,
+	}
+}
+
+func (m model) Init() tea.Cmd {
+	return tea.Batch(m.spinner.Tick, startStage(m.stage))
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "q", "ctrl+c":
+			m.quitting = true
+			return m, tea.Quit
+
+		default:
+			return m, nil
+		}
+
+	case errMsg:
+		m.err = msg
+		return m, tea.Quit
+
+	case cleanUpStage:
+		m.stage = msg
+
+		if msg == Done {
+			return m, tea.Quit
+		}
+
+		return m, startStage(m.stage)
+
+	default:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+	}
+
+}
+
+func (m model) View() string {
+	if m.err != nil {
+		return fmt.Sprintf("\nSomething went wrong: %v\n\n", m.err)
+	}
+
+	builder := strings.Builder{}
+
+	stageMsg, mappingErr := mapStageToMessage(m.stage)
+	if mappingErr != nil {
+		return mappingErr.Error()
+	}
+
+	fmt.Fprintf(&builder, "\n  %s %s... ", m.spinner.View(), stageMsg)
+	fmt.Fprint(&builder, helpStyle.Render("(q to quit)"))
+
+	if m.quitting {
+		builder.WriteString("\n")
+		return builder.String()
+	}
+
+	return builder.String()
+}
+
+func mapStageToMessage(stage cleanUpStage) (string, error) {
+	var message string
+
+	switch stage {
+	case FetchPrune:
+		message = "Fetching remote branches"
+	case Find:
+		message = "Finding local branches not on remote"
+	case Delete:
+		message = "Deleting local branches not on remote"
+	case Done:
+		message = "Done"
+	default:
+		return "", errStageMappingError
+	}
+
+	return message, nil
+}

--- a/git.go
+++ b/git.go
@@ -13,7 +13,7 @@ func findBranches(pattern string) []string {
 	globPattern := fmt.Sprintf("%s*", pattern)
 	out, err := exec.Command("git", "branch", "--list", globPattern, "--format", "%(refname:short)").CombinedOutput()
 	if err != nil {
-		log.Fatalf("Error finding branches: %v", err)
+		log.Fatalf("Error finding branches: %v\n", err)
 	}
 
 	fromBytes := string(out[:])
@@ -26,7 +26,7 @@ func findBranches(pattern string) []string {
 func getCurrentBranchName() string {
 	out, err := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD").CombinedOutput()
 	if err != nil {
-		log.Fatalf("Error getting current branch: %v", err)
+		log.Fatalf("Error getting current branch: %v\n", err)
 	}
 
 	fromBytes := string(out[:])
@@ -37,7 +37,7 @@ func getCurrentBranchName() string {
 func switchBranch(branchName string) string {
 	out, err := exec.Command("git", "switch", branchName).CombinedOutput()
 	if err != nil {
-		log.Fatalf("Error switching branch: %v", err)
+		log.Fatalf("Error switching branch: %v\n", err)
 	}
 
 	return string(out[:])
@@ -47,7 +47,7 @@ func switchBranch(branchName string) string {
 func deleteBranch(branchName string) string {
 	out, err := exec.Command("git", "branch", "-D", branchName).CombinedOutput()
 	if err != nil {
-		log.Fatalf("Error deleting branch: %v", err)
+		log.Fatalf("Error deleting branch: %v\n", err)
 	}
 
 	return string(out[:])

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/suvanl/mybranches
 go 1.23.5
 
 require (
+	github.com/charmbracelet/bubbles v0.20.0
 	github.com/charmbracelet/bubbletea v1.2.4
 	github.com/charmbracelet/lipgloss v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/charmbracelet/bubbles v0.20.0 h1:jSZu6qD8cRQ6k9OMfR1WlM+ruM8fkPWkHvQWD9LIutE=
+github.com/charmbracelet/bubbles v0.20.0/go.mod h1:39slydyswPy+uVOHZ5x/GjwVAFkCsV8IIVy+4MhzwwU=
 github.com/charmbracelet/bubbletea v1.2.4 h1:KN8aCViA0eps9SCOThb2/XPIlea3ANJLUkv3KnQRNCE=
 github.com/charmbracelet/bubbletea v1.2.4/go.mod h1:Qr6fVQw+wX7JkWWkVyXYk/ZUQ92a6XNekLXa3rR18MM=
 github.com/charmbracelet/lipgloss v1.0.0 h1:O7VkGDvqEdGi93X+DeqsQ7PKHDgtQfF8j8/O2qFMQNg=

--- a/mybranches.go
+++ b/mybranches.go
@@ -19,7 +19,7 @@ func main() {
 	if *cleanupFlag {
 		hasCustomPatternFlag := *patternFlag != getUsernamePattern()
 		if hasCustomPatternFlag {
-			fmt.Println("  ⚠️ Specified -pattern flag with -cleanup. The cleanup flag takes precedence; the pattern flag will be ignored.")
+			fmt.Println("  ⚠️ Ignoring --pattern flag because --cleanup flag was set to true")
 		}
 
 		// Run cleanup program

--- a/mybranches.go
+++ b/mybranches.go
@@ -7,15 +7,36 @@ import (
 	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/suvanl/mybranches/cleanup"
 )
 
 func main() {
-	pattern := flag.String("pattern", getUsernamePattern(), "Custom pattern to use. Defaults to your username.")
+	patternFlag := flag.String("pattern", getUsernamePattern(), "Custom pattern to use. Defaults to your username.")
+	cleanupFlag := flag.Bool("cleanup", false, "Delete all local branches that aren't on remote")
+
 	flag.Parse()
 
-	branches := findBranches(*pattern)
+	if *cleanupFlag {
+		hasCustomPatternFlag := *patternFlag != getUsernamePattern()
+		if hasCustomPatternFlag {
+			fmt.Println("  ⚠️ Specified -pattern flag with -cleanup. The cleanup flag takes precedence; the pattern flag will be ignored.")
+		}
+
+		// Run cleanup program
+		program := tea.NewProgram(cleanup.InitialState())
+		_, err := program.Run()
+
+		if err != nil {
+			fmt.Printf("Something went wrong: %v", err)
+			os.Exit(1)
+		}
+
+		return
+	}
+
+	branches := findBranches(*patternFlag)
 	if len(branches) == 0 {
-		fmt.Printf("Couldn't find any branches containing '%s'\n", *pattern)
+		fmt.Printf("Couldn't find any branches containing '%s'\n", *patternFlag)
 		return
 	}
 

--- a/shared/git/git.go
+++ b/shared/git/git.go
@@ -1,0 +1,10 @@
+package git
+
+import "os/exec"
+
+// git fetch --prune
+func FetchPrune() error {
+	// TODO: add prune back!
+	_, err := exec.Command("git", "fetch").CombinedOutput()
+	return err
+}

--- a/shared/git/git.go
+++ b/shared/git/git.go
@@ -4,7 +4,6 @@ import "os/exec"
 
 // git fetch --prune
 func FetchPrune() error {
-	// TODO: add prune back!
-	_, err := exec.Command("git", "fetch").CombinedOutput()
+	_, err := exec.Command("git", "fetch", "--prune").CombinedOutput()
 	return err
 }

--- a/shared/git/git_other.go
+++ b/shared/git/git_other.go
@@ -1,0 +1,103 @@
+//go:build !windows
+
+package git
+
+import (
+	"bufio"
+	"bytes"
+	"log"
+	"os/exec"
+	"strings"
+)
+
+func DeleteBranchesNotOnRemote() (int, error) {
+	branches, err := getGoneBranches()
+	if err != nil {
+		return -1, err
+	}
+
+	// todo: Delete all the gone branches
+
+	return len(branches), nil
+}
+
+func getGoneBranches() ([]string, error) {
+	branch := exec.Command("git", "branch", "-vv")
+	grep := exec.Command("grep", "'gone]'")
+	awk := exec.Command("awk", "'{print $1}'")
+
+	// Set up pipes between commands
+
+	branchOut, err := branch.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	grepIn, err := grep.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	grepOut, err := grep.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	awkIn, err := awk.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	// Start commands
+
+	if err := branch.Start(); err != nil {
+		return nil, err
+	}
+
+	if err := grep.Start(); err != nil {
+		return nil, err
+	}
+
+	if err := awk.Start(); err != nil {
+		return nil, err
+	}
+
+	// Join pipes
+
+	go func() {
+		defer grepIn.Close()
+		if _, err := bufio.NewReader(branchOut).WriteTo(grepIn); err != nil {
+			log.Fatalln(err)
+		}
+	}()
+
+	go func() {
+		defer awkIn.Close()
+		if _, err := bufio.NewReader(grepOut).WriteTo(awkIn); err != nil {
+			log.Fatalln(err)
+		}
+	}()
+
+	// Finish commands + collect output
+
+	var awkOut bytes.Buffer
+	awk.Stdout = &awkOut
+
+	if err := branch.Wait(); err != nil {
+		return nil, err
+	}
+
+	// ! fixme
+	if err := grep.Wait(); err != nil {
+		return nil, err
+	}
+
+	if err := awk.Wait(); err != nil {
+		return nil, err
+	}
+
+	output := strings.TrimSpace(awkOut.String())
+	branchNames := strings.Split(output, "\n")
+
+	return branchNames, nil
+}

--- a/shared/git/git_other.go
+++ b/shared/git/git_other.go
@@ -22,6 +22,7 @@ func DeleteBranchesNotOnRemote(dryRun bool) (int, error) {
 func getGoneBranches(dryRun bool) ([]string, error) {
 	// Introduces a dependency on sh, which may symlink to different shells depending on the platform this is running on.
 	// This is simpler than programmatically piping the commands between each other; let's delegate that work for now.
+	// If it starts to lead to inconsistent behaviour across platforms, might be a good idea to revisit this.
 
 	cmd := "git branch -vv | grep 'gone]' | awk '{print $1}'"
 	if !dryRun {

--- a/shared/git/git_other.go
+++ b/shared/git/git_other.go
@@ -7,30 +7,37 @@ import (
 	"strings"
 )
 
-func DeleteBranchesNotOnRemote() (int, error) {
-	branches, err := getGoneBranches()
+// DeleteBranchesNotOnRemote finds 'gone' branches and optionally deletes them if dryRun is false.
+//
+// Returns number of branches deleted and error (if any)
+func DeleteBranchesNotOnRemote(dryRun bool) (int, error) {
+	branches, err := getGoneBranches(dryRun)
 	if err != nil {
 		return -1, err
 	}
 
-	// todo: Delete all the gone branches
-
 	return len(branches), nil
 }
 
-func getGoneBranches() ([]string, error) {
+func getGoneBranches(dryRun bool) ([]string, error) {
 	// Introduces a dependency on sh, which may symlink to different shells depending on the platform this is running on.
 	// This is simpler than programmatically piping the commands between each other; let's delegate that work for now.
-	out, err := exec.Command("sh", "-c", "git branch -vv | grep 'gone]' | awk '{print $1}'").CombinedOutput()
+
+	cmd := "git branch -vv | grep 'gone]' | awk '{print $1}'"
+	if !dryRun {
+		cmd += " | xargs git branch -D"
+	}
+
+	out, err := exec.Command("sh", "-c", cmd).CombinedOutput()
 	if err != nil {
 		return nil, err
 	}
 
-	outStr := strings.TrimSpace(string(out[:]))
-	if outStr == "" {
+	result := strings.TrimSpace(string(out[:]))
+	if result == "" {
 		return []string{}, nil
 	}
 
-	branchNames := strings.Split(outStr, "\n")
+	branchNames := strings.Split(result, "\n")
 	return branchNames, nil
 }

--- a/shared/git/git_other.go
+++ b/shared/git/git_other.go
@@ -3,9 +3,6 @@
 package git
 
 import (
-	"bufio"
-	"bytes"
-	"log"
 	"os/exec"
 	"strings"
 )
@@ -22,82 +19,18 @@ func DeleteBranchesNotOnRemote() (int, error) {
 }
 
 func getGoneBranches() ([]string, error) {
-	branch := exec.Command("git", "branch", "-vv")
-	grep := exec.Command("grep", "'gone]'")
-	awk := exec.Command("awk", "'{print $1}'")
-
-	// Set up pipes between commands
-
-	branchOut, err := branch.StdoutPipe()
+	// Introduces a dependency on sh, which may symlink to different shells depending on the platform this is running on.
+	// This is simpler than programmatically piping the commands between each other; let's delegate that work for now.
+	out, err := exec.Command("sh", "-c", "git branch -vv | grep 'gone]' | awk '{print $1}'").CombinedOutput()
 	if err != nil {
 		return nil, err
 	}
 
-	grepIn, err := grep.StdinPipe()
-	if err != nil {
-		return nil, err
+	outStr := strings.TrimSpace(string(out[:]))
+	if outStr == "" {
+		return []string{}, nil
 	}
 
-	grepOut, err := grep.StdoutPipe()
-	if err != nil {
-		return nil, err
-	}
-
-	awkIn, err := awk.StdinPipe()
-	if err != nil {
-		return nil, err
-	}
-
-	// Start commands
-
-	if err := branch.Start(); err != nil {
-		return nil, err
-	}
-
-	if err := grep.Start(); err != nil {
-		return nil, err
-	}
-
-	if err := awk.Start(); err != nil {
-		return nil, err
-	}
-
-	// Join pipes
-
-	go func() {
-		defer grepIn.Close()
-		if _, err := bufio.NewReader(branchOut).WriteTo(grepIn); err != nil {
-			log.Fatalln(err)
-		}
-	}()
-
-	go func() {
-		defer awkIn.Close()
-		if _, err := bufio.NewReader(grepOut).WriteTo(awkIn); err != nil {
-			log.Fatalln(err)
-		}
-	}()
-
-	// Finish commands + collect output
-
-	var awkOut bytes.Buffer
-	awk.Stdout = &awkOut
-
-	if err := branch.Wait(); err != nil {
-		return nil, err
-	}
-
-	// ! fixme
-	if err := grep.Wait(); err != nil {
-		return nil, err
-	}
-
-	if err := awk.Wait(); err != nil {
-		return nil, err
-	}
-
-	output := strings.TrimSpace(awkOut.String())
-	branchNames := strings.Split(output, "\n")
-
+	branchNames := strings.Split(outStr, "\n")
 	return branchNames, nil
 }

--- a/shared/git/git_windows.go
+++ b/shared/git/git_windows.go
@@ -5,6 +5,6 @@ package git
 import "log"
 
 func DeleteBranchesNotOnRemote(dryRun bool) (int, error) {
-	log.Fatalln("DeleteBranchesNotOnRemote: windows not yet supported")
+	log.Fatalln("DeleteBranchesNotOnRemote: Windows not yet supported")
 	return -1, nil
 }

--- a/shared/git/git_windows.go
+++ b/shared/git/git_windows.go
@@ -4,7 +4,7 @@ package git
 
 import "log"
 
-func DeleteBranchesNotOnRemote() (int32, error) {
+func DeleteBranchesNotOnRemote(dryRun bool) (int, error) {
 	log.Fatalln("DeleteBranchesNotOnRemote: windows not yet supported")
 	return -1, nil
 }

--- a/shared/git/git_windows.go
+++ b/shared/git/git_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package git
+
+import "log"
+
+func DeleteBranchesNotOnRemote() (int32, error) {
+	log.Fatalln("DeleteBranchesNotOnRemote: windows not yet supported")
+	return -1, nil
+}


### PR DESCRIPTION
Would be useful if it was possible to clean up all local branches that are no longer on remote to keep the branch list as short as possible.

This feature will be a separate bubbletea program which can be run by using the `--cleanup` flag